### PR TITLE
Add option to use new Traefik CRDs group

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ oidcProviders:
     audience: ["app1"]
 ```
 
+If your Traefik install already uses the `traefik.io` CRDs instead of the old `traefik.containo.us` CRDs be sure to add this to your values file:
+
+```yaml
+useDeprecatedTraefikApiGroup: false
+```
+
 Last, enable it in the ingress controller of the service `app.example.com` you would like to protect:
 
 ```yaml

--- a/helm/templates/middleware.yaml
+++ b/helm/templates/middleware.yaml
@@ -1,4 +1,8 @@
+{{ if .Values.useDeprecatedTraefikApiGroup }}
 apiVersion: traefik.containo.us/v1alpha1
+{{ else }}
+apiVersion: traefik.io/v1alpha1
+{{ end }}
 kind: Middleware
 metadata:
   name: oidc-forward-auth-middleware

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -50,6 +50,10 @@ extraEnvVars:
   # - name: EXAMPLE_ENV
   #   value: ABCD
 
+# TODO Flip to false or remove once deprecated CRDs have been removed once and for all
+# See https://github.com/traefik/traefik/issues/9125
+useDeprecatedTraefikApiGroup: true
+
 autoscaling:
   enabled: false
   minReplicas: 1


### PR DESCRIPTION
Added optimal value to use the new Traefik CRDs group. Designed to not break existing installs.

Closes #7 