### PR TITLE
Allow setting listen address at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ For the latest example have a look at the `docker-compose.yml` file.
 | Environment variable      | Type    | Description                                                                                |
 | ------------------------- | ------- | ------------------------------------------------------------------------------------------ |
 | RUST_LOG                  | String  | info, debug, error, warning                                                                |
+| BIND_ADDRESS              | String  | Default: `0.0.0.0:3000`. The network address to bind to.                                   |
 | DISABLE_ENHANCED_SECURITY | Boolean | Default: `false`. Sets various security HTTP headers and redirects http requests to https. |
 | REDIS_URL                 | String  | Optional. Redis/Valkey connection URL for session store. Example: `redis://localhost:6379` |
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -923,7 +923,7 @@ async fn main() {
         );
 
     let service = Service::new(router).hoop(Logger::new());
-    let acceptor = TcpListener::new("0.0.0.0:3000").bind().await;
+    let acceptor = TcpListener::new(env::var("BIND_ADDRESS").unwrap_or("0.0.0.0:3000".to_owned())).bind().await;
 
     Server::new(acceptor).serve(service).await;
 }


### PR DESCRIPTION
Allows setting the listen address with the `BIND_ADDRESS` env var. Defaults to `0.0.0.0:3000` if `BIND_ADDRESS` is unset.
This helps with running the middleware outside of a container, where port 3000 may be unavailable or listening on all interfaces may be undesirable.